### PR TITLE
d/prerm: Remove conflicting conf files on removal

### DIFF
--- a/debian/phosh-config-hwcomposer.prerm
+++ b/debian/phosh-config-hwcomposer.prerm
@@ -2,6 +2,7 @@
 
 remove() {
 	rm -f /etc/systemd/system/phosh.service.d/90-force-legacy-user.conf
+	rm -f /etc/systemd/system/android-service@hwcomposer.service.d/20-phosh.conf
 }
 
 case "$1" in


### PR DESCRIPTION
`/etc/systemd/system/android-service@hwcomposer.service.d/20-phosh.conf` should only exist if the package is installed and can cause conflicts and problems if left intact on removal. Debuild however detects this as a conf file and leaves it intact when removing the package (a purge is needed).

Therefore, this file shall be removed in prerm.