### PR TITLE
debian: Move conf files to /usr/lib

### DIFF
--- a/debian/phosh-config-hwcomposer.dirs
+++ b/debian/phosh-config-hwcomposer.dirs
@@ -1,2 +1,2 @@
-/etc/systemd/system/phosh.service.d
-/etc/systemd/system/android-service@hwcomposer.service.d
+/usr/lib/systemd/system/phosh.service.d
+/usr/lib/systemd/system/android-service@hwcomposer.service.d

--- a/debian/phosh-config-hwcomposer.install
+++ b/debian/phosh-config-hwcomposer.install
@@ -1,2 +1,2 @@
-phosh.service.d/* /etc/systemd/system/phosh.service.d/
-android-service@hwcomposer.service.d/* /etc/systemd/system/android-service@hwcomposer.service.d/
+phosh.service.d/* /usr/lib/systemd/system/phosh.service.d/
+android-service@hwcomposer.service.d/* /usr/lib/systemd/system/android-service@hwcomposer.service.d/

--- a/debian/phosh-config-hwcomposer.maintscript
+++ b/debian/phosh-config-hwcomposer.maintscript
@@ -1,0 +1,4 @@
+rm_conffile /etc/systemd/system/phosh.service.d/40-droid-wait.conf 14~
+rm_conffile /etc/systemd/system/phosh.service.d/30-force-user.conf 14~
+rm_conffile /etc/systemd/system/phosh.service.d/20-wlroots-hwc-env.conf 14~
+rm_conffile /etc/systemd/system/android-service@hwcomposer.service.d/20-phosh.conf 14~


### PR DESCRIPTION
debhelper assumes everything in /etc is a conf file. This means they won't be removed on removal (only on purge) and they won't be upgraded/installed if edited/removed manually.

For example, this is a problem if user wants to swap their installation from phosh to cutie. In this scenario, the phosh conf for `android-service@hwcomposer.service` still remains on the system and prevents cutie from starting: "Could not find phosh.service"

Therefore, we should install these files in /usr/lib (systemd still reads from there).